### PR TITLE
modified script search button and css logo bg

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -27,6 +27,8 @@ body {
   padding-left: 1em;
   padding-top: 0.3em;
   font-size: 250%;
+  background-color: #061113;
+  border-radius: 1em;
 }
 
 a:hover {

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -21,6 +21,7 @@ document.querySelector("header").addEventListener("click", function () {
 //when search button is clicked or enter key is pressed, assign the input value to "location", and call the functions
 $("#searchButton").click(function () {
     let location = $("#searchInput").val();
+    document.querySelector("#searchInput").value = "";
     scrollToWikiArticle();
     checkValue(location);
     mapCall(location);
@@ -28,6 +29,7 @@ $("#searchButton").click(function () {
 $("#searchInput").on("keydown", function (event) {
     if (event.key == "Enter") { //checks if key press is the enter key.
         let location = $("#searchInput").val();
+        document.querySelector("#searchInput").value = "";
         scrollToWikiArticle();
         checkValue(location);
         mapCall(location);


### PR DESCRIPTION
added document selecter to scritp so when a user enters text and clicks search or presses enter the text erases from search input/box.
```javascript
$("#searchButton").click(function () {
    let location = $("#searchInput").val();
    document.querySelector("#searchInput").value = ""; // added this line
    scrollToWikiArticle();
    checkValue(location);
    mapCall(location);
});
$("#searchInput").on("keydown", function (event) {
    if (event.key == "Enter") { //checks if key press is the enter key.
        let location = $("#searchInput").val();
        document.querySelector("#searchInput").value = ""; // added this line
        scrollToWikiArticle();
        checkValue(location);
        mapCall(location);
    }
});
```

also added a background color to just the logo so its easier to see it when it scrolls over text on responsive sizes.
```css
#logo {
  padding-left: 1em;
  padding-top: 0.3em;
  font-size: 250%;
  background-color: #061113; /* added this line */
  border-radius: 1em;
}
```
<img width="789" alt="image" src="https://user-images.githubusercontent.com/20311430/216611129-67baa5c9-b8d2-46e0-bf58-8129fceb3e52.png">
